### PR TITLE
Normalize Agent mapping in both conversion directions

### DIFF
--- a/internal/claude/writer.go
+++ b/internal/claude/writer.go
@@ -3,12 +3,14 @@ package claude
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,6 +21,7 @@ import (
 var ErrWrite = errors.New("claude native write failed")
 
 const defaultClaudeVersion = "2.1.63"
+const claudeToolIDLength = 24
 
 type Writer struct {
 	ClaudeHome string
@@ -95,6 +98,7 @@ func writeSessionJSONL(path, sessionID, cwd, gitBranch string, startedAt time.Ti
 	}
 
 	callIDMap := map[string]string{}
+	callInfoMap := map[string]toolCallInfo{}
 	droppedCalls := map[string]bool{} // source IDs of lifecycle tool calls to drop
 	prevUUID := ""
 	eventTS := startedAt
@@ -179,10 +183,14 @@ func writeSessionJSONL(path, sessionID, cwd, gitBranch string, startedAt time.Ti
 				callCount++
 				sourceID = fmt.Sprintf("call_missing_%d", callCount)
 			}
-			claudeToolID := "toolu_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+			claudeToolID := newClaudeToolUseID()
 			callIDMap[sourceID] = claudeToolID
 
 			toolName, toolInput := normalizeCodexToolForClaude(ev.Call.Name, ev.Call.Input)
+			callInfoMap[sourceID] = toolCallInfo{
+				Name:  toolName,
+				Input: cloneMap(toolInput),
+			}
 			line := cloneMap(base)
 			line["type"] = "assistant"
 			line["message"] = map[string]any{
@@ -218,12 +226,14 @@ func writeSessionJSONL(path, sessionID, cwd, gitBranch string, startedAt time.Ti
 			}
 			toolUseID := callIDMap[callSourceID]
 			if toolUseID == "" {
-				toolUseID = "toolu_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+				toolUseID = newClaudeToolUseID()
 			}
-			output := strings.TrimSpace(ev.Result.Output)
+			output := normalizeToolResultOutput(ev.Result.Output)
 			if output == "" {
 				output = "[no output recorded]"
 			}
+			callInfo := callInfoMap[callSourceID]
+			toolUseResult := buildToolUseResult(callInfo.Name, callInfo.Input, output, ev.Result.Output)
 
 			line := cloneMap(base)
 			line["type"] = "user"
@@ -237,7 +247,7 @@ func writeSessionJSONL(path, sessionID, cwd, gitBranch string, startedAt time.Ti
 					},
 				},
 			}
-			line["toolUseResult"] = output
+			line["toolUseResult"] = toolUseResult
 			if err := writeLine(line); err != nil {
 				return err
 			}
@@ -285,6 +295,243 @@ func chooseTS(ev session.Event, fallback, startedAt time.Time) time.Time {
 	return startedAt.UTC()
 }
 
+type toolCallInfo struct {
+	Name  string
+	Input map[string]any
+}
+
+func buildToolUseResult(toolName string, toolInput map[string]any, output, rawOutput string) any {
+	switch strings.TrimSpace(toolName) {
+	case "Edit", "Write", "MultiEdit":
+		return buildFileToolUseResult(toolInput)
+	case "Bash":
+		return buildBashToolUseResult(output, rawOutput)
+	case "Agent":
+		return buildAgentToolUseResult(toolInput, output, rawOutput)
+	default:
+		return output
+	}
+}
+
+func buildFileToolUseResult(toolInput map[string]any) map[string]any {
+	if toolInput == nil {
+		toolInput = map[string]any{}
+	}
+
+	filePath := firstNonEmptyString(toolInput["file_path"], toolInput["filePath"], toolInput["path"])
+	oldString := firstNonEmptyString(toolInput["old_string"], toolInput["oldString"])
+	newString := firstNonEmptyString(toolInput["new_string"], toolInput["newString"], toolInput["content"])
+	originalFile := firstNonEmptyString(toolInput["original_file"], toolInput["originalFile"], oldString)
+	if originalFile == "" && filePath != "" {
+		if b, err := os.ReadFile(filePath); err == nil {
+			originalFile = string(b)
+		}
+	}
+
+	replaceAll := false
+	if b, ok := asBoolValue(toolInput["replace_all"]); ok {
+		replaceAll = b
+	} else if b, ok := asBoolValue(toolInput["replaceAll"]); ok {
+		replaceAll = b
+	}
+
+	userModified := false
+	if b, ok := asBoolValue(toolInput["user_modified"]); ok {
+		userModified = b
+	} else if b, ok := asBoolValue(toolInput["userModified"]); ok {
+		userModified = b
+	}
+
+	structuredPatch := []map[string]any{}
+	if oldString != "" || newString != "" {
+		structuredPatch = append(structuredPatch, map[string]any{
+			"oldStart": 1,
+			"oldLines": countLines(oldString),
+			"newStart": 1,
+			"newLines": countLines(newString),
+			"lines":    buildPatchLines(oldString, newString),
+		})
+	}
+
+	return map[string]any{
+		"filePath":        filePath,
+		"oldString":       oldString,
+		"newString":       newString,
+		"originalFile":    originalFile,
+		"structuredPatch": structuredPatch,
+		"userModified":    userModified,
+		"replaceAll":      replaceAll,
+	}
+}
+
+func buildPatchLines(oldString, newString string) []string {
+	lines := make([]string, 0, countLines(oldString)+countLines(newString))
+	if oldString != "" {
+		for _, line := range strings.Split(oldString, "\n") {
+			lines = append(lines, "-"+line)
+		}
+	}
+	if newString != "" {
+		for _, line := range strings.Split(newString, "\n") {
+			lines = append(lines, "+"+line)
+		}
+	}
+	return lines
+}
+
+func countLines(s string) int {
+	if s == "" {
+		return 0
+	}
+	return strings.Count(s, "\n") + 1
+}
+
+func buildBashToolUseResult(output, rawOutput string) map[string]any {
+	stdout := output
+	stderr := ""
+	interrupted := false
+	isImage := false
+	noOutputExpected := false
+
+	if payload, ok := parseJSONMap(rawOutput); ok {
+		if s, ok := payload["stdout"]; ok {
+			stdout = asStringValue(s)
+		}
+		if s, ok := payload["stderr"]; ok {
+			stderr = asStringValue(s)
+		}
+		if b, ok := asBoolValue(payload["interrupted"]); ok {
+			interrupted = b
+		}
+		if b, ok := asBoolValue(payload["isImage"]); ok {
+			isImage = b
+		}
+		if b, ok := asBoolValue(payload["noOutputExpected"]); ok {
+			noOutputExpected = b
+		}
+	}
+
+	return map[string]any{
+		"stdout":           stdout,
+		"stderr":           stderr,
+		"interrupted":      interrupted,
+		"isImage":          isImage,
+		"noOutputExpected": noOutputExpected,
+	}
+}
+
+func buildAgentToolUseResult(toolInput map[string]any, output, rawOutput string) map[string]any {
+	if toolInput == nil {
+		toolInput = map[string]any{}
+	}
+
+	payload := map[string]any{}
+	if p, ok := parseJSONMap(rawOutput); ok {
+		payload = p
+	} else if p, ok := parseJSONMap(output); ok {
+		payload = p
+	}
+
+	agentID := firstNonEmptyString(payload["agent_id"], payload["agentId"], payload["id"])
+	status := strings.TrimSpace(asStringValue(payload["status"]))
+	if status == "" {
+		if agentID != "" {
+			status = "completed"
+		} else {
+			status = "unknown"
+		}
+	}
+
+	content := output
+	if s := strings.TrimSpace(asStringValue(payload["content"])); s != "" {
+		content = s
+	}
+
+	usage := map[string]any{}
+	if u, ok := payload["usage"].(map[string]any); ok {
+		usage = u
+	}
+
+	totalDurationMs, _ := asIntValue(payload["totalDurationMs"])
+	totalTokens, _ := asIntValue(payload["totalTokens"])
+	totalToolUseCount, _ := asIntValue(payload["totalToolUseCount"])
+
+	return map[string]any{
+		"agentId":           agentID,
+		"status":            status,
+		"prompt":            firstNonEmptyString(toolInput["prompt"], toolInput["message"]),
+		"content":           content,
+		"totalDurationMs":   totalDurationMs,
+		"totalTokens":       totalTokens,
+		"totalToolUseCount": totalToolUseCount,
+		"usage":             usage,
+	}
+}
+
+func parseJSONMap(raw string) (map[string]any, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, false
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil || payload == nil {
+		return nil, false
+	}
+	return payload, true
+}
+
+func asBoolValue(v any) (bool, bool) {
+	switch x := v.(type) {
+	case bool:
+		return x, true
+	case string:
+		switch strings.ToLower(strings.TrimSpace(x)) {
+		case "true":
+			return true, true
+		case "false":
+			return false, true
+		}
+	}
+	return false, false
+}
+
+func asIntValue(v any) (int, bool) {
+	switch x := v.(type) {
+	case int:
+		return x, true
+	case int8:
+		return int(x), true
+	case int16:
+		return int(x), true
+	case int32:
+		return int(x), true
+	case int64:
+		return int(x), true
+	case uint:
+		return int(x), true
+	case uint8:
+		return int(x), true
+	case uint16:
+		return int(x), true
+	case uint32:
+		return int(x), true
+	case uint64:
+		return int(x), true
+	case float32:
+		return int(x), true
+	case float64:
+		return int(x), true
+	case string:
+		n, err := strconv.Atoi(strings.TrimSpace(x))
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	default:
+		return 0, false
+	}
+}
+
 func normalizeCodexToolForClaude(name string, input map[string]any) (string, map[string]any) {
 	name = strings.TrimSpace(name)
 	if input == nil {
@@ -315,9 +562,58 @@ func normalizeCodexToolForClaude(name string, input map[string]any) (string, map
 			"new_string": patch,
 		}
 
+	case "edit":
+		out := cloneMap(input)
+		filePath := firstNonEmptyString(
+			out["file_path"],
+			out["filePath"],
+			out["path"],
+		)
+		out["file_path"] = filePath
+		delete(out, "filePath")
+		return "Edit", out
+
+	case "multiedit":
+		out := cloneMap(input)
+		filePath := firstNonEmptyString(
+			out["file_path"],
+			out["filePath"],
+			out["path"],
+		)
+		out["file_path"] = filePath
+		delete(out, "filePath")
+		return "MultiEdit", out
+
 	case "view_image":
 		path := strings.TrimSpace(asStringValue(input["path"]))
 		return "Read", map[string]any{"file_path": path}
+
+	case "read":
+		out := cloneMap(input)
+		filePath := firstNonEmptyString(
+			out["file_path"],
+			out["filePath"],
+			out["path"],
+		)
+		clean := map[string]any{"file_path": filePath}
+		if v, ok := out["offset"]; ok {
+			clean["offset"] = v
+		}
+		if v, ok := out["limit"]; ok {
+			clean["limit"] = v
+		}
+		return "Read", clean
+
+	case "write":
+		out := cloneMap(input)
+		filePath := firstNonEmptyString(
+			out["file_path"],
+			out["filePath"],
+			out["path"],
+		)
+		out["file_path"] = filePath
+		delete(out, "filePath")
+		return "Write", out
 
 	case "spawn_agent":
 		prompt := strings.TrimSpace(asStringValue(input["message"]))
@@ -387,6 +683,68 @@ func asStringValue(v any) string {
 	default:
 		return ""
 	}
+}
+
+func normalizeToolResultOutput(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	tryParse := func(s string) (map[string]any, bool) {
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(s), &payload); err != nil || payload == nil {
+			return nil, false
+		}
+		return payload, true
+	}
+
+	// Codex custom tool outputs commonly wrap textual stdout in {"output":"...","metadata":{...}}.
+	// Unwrap that shape so Claude renders native tool results as plain text.
+	if payload, ok := tryParse(raw); ok {
+		if _, hasMetadata := payload["metadata"]; hasMetadata {
+			if out := strings.TrimSpace(asStringValue(payload["output"])); out != "" {
+				return out
+			}
+		}
+		return raw
+	}
+
+	// Some captured outputs decode into strings containing literal newlines/tabs,
+	// which makes the wrapper JSON invalid for strict parsing. Re-escape controls
+	// and retry extraction.
+	sanitized := strings.NewReplacer("\r", "\\r", "\n", "\\n", "\t", "\\t").Replace(raw)
+	if payload, ok := tryParse(sanitized); ok {
+		if _, hasMetadata := payload["metadata"]; hasMetadata {
+			if out := strings.TrimSpace(asStringValue(payload["output"])); out != "" {
+				return out
+			}
+		}
+	}
+	return raw
+}
+
+func firstNonEmptyString(vals ...any) string {
+	for _, v := range vals {
+		if s := strings.TrimSpace(asStringValue(v)); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func newClaudeToolUseID() string {
+	const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	buf := make([]byte, claudeToolIDLength)
+	if _, err := rand.Read(buf); err != nil {
+		// Keep conversion robust even if random source fails.
+		return "toolu_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	}
+	out := make([]byte, claudeToolIDLength)
+	for i := range buf {
+		out[i] = alphabet[int(buf[i])%len(alphabet)]
+	}
+	return "toolu_" + string(out)
 }
 
 type sessionsIndexEntry struct {

--- a/internal/claude/writer.go
+++ b/internal/claude/writer.go
@@ -30,6 +30,7 @@ const claudeTruncatedKeepChars = 256
 const claudeToolInputSoftLimitChars = 1_024
 const claudeEventHardLimitChars = 2_048
 const claudeToolInputHardLimitChars = 1_024
+const claudeTruncationPrefix = "[truncated for target model context;"
 
 type Writer struct {
 	ClaudeHome string
@@ -330,7 +331,7 @@ func normalizeEventsForClaudeContext(events []session.Event, maxChars int) []ses
 	}{
 		{keepChars: claudeTruncatedKeepChars, toolInputSoftLimit: claudeToolInputSoftLimitChars},
 		{keepChars: 96, toolInputSoftLimit: 256},
-		{keepChars: 24, toolInputSoftLimit: 64},
+		{keepChars: 64, toolInputSoftLimit: 64},
 	}
 	for _, pass := range passPlan {
 		for i := 0; i < len(out) && total > maxChars; i++ {
@@ -408,12 +409,31 @@ func truncateForContext(s string, keepChars int) string {
 	if keepChars <= 0 {
 		keepChars = claudeTruncatedKeepChars
 	}
-	if len(s) <= keepChars {
-		return s
+	base := s
+	if body, ok := unwrapTruncatedBody(s); ok {
+		base = body
+		if len(base) <= keepChars {
+			// Already truncated and body is within limit; keep existing envelope.
+			return s
+		}
 	}
-	head := s[:keepChars]
-	removed := len(s) - keepChars
-	return fmt.Sprintf("[truncated for target model context; original chars=%d, removed=%d]\n%s", len(s), removed, head)
+	if len(base) <= keepChars {
+		return base
+	}
+	head := base[:keepChars]
+	removed := len(base) - keepChars
+	return fmt.Sprintf("[truncated for target model context; original chars=%d, removed=%d]\n%s", len(base), removed, head)
+}
+
+func unwrapTruncatedBody(s string) (string, bool) {
+	if !strings.HasPrefix(s, claudeTruncationPrefix) {
+		return "", false
+	}
+	newline := strings.IndexByte(s, '\n')
+	if newline < 0 || newline+1 >= len(s) {
+		return "", false
+	}
+	return s[newline+1:], true
 }
 
 func truncateInputForContext(in map[string]any, limit int) map[string]any {

--- a/internal/claude/writer.go
+++ b/internal/claude/writer.go
@@ -308,6 +308,8 @@ func buildToolUseResult(toolName string, toolInput map[string]any, output, rawOu
 		return buildBashToolUseResult(output, rawOutput)
 	case "Agent":
 		return buildAgentToolUseResult(toolInput, output, rawOutput)
+	case "AskUserQuestion":
+		return buildAskUserQuestionToolUseResult(toolInput, output, rawOutput)
 	default:
 		return output
 	}
@@ -466,6 +468,92 @@ func buildAgentToolUseResult(toolInput map[string]any, output, rawOutput string)
 		"totalToolUseCount": totalToolUseCount,
 		"usage":             usage,
 	}
+}
+
+func buildAskUserQuestionToolUseResult(toolInput map[string]any, output, rawOutput string) any {
+	payload := map[string]any{}
+	if p, ok := parseJSONMap(rawOutput); ok {
+		payload = p
+	} else if p, ok := parseJSONMap(output); ok {
+		payload = p
+	} else {
+		return output
+	}
+
+	rawAnswers, ok := payload["answers"].(map[string]any)
+	if !ok || rawAnswers == nil {
+		return output
+	}
+
+	questions := []any{}
+	questionByID := map[string]string{}
+	if toolInput != nil {
+		if list, ok := toolInput["questions"].([]any); ok {
+			questions = list
+			for _, item := range list {
+				question, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				questionID := strings.TrimSpace(asStringValue(question["id"]))
+				questionText := strings.TrimSpace(asStringValue(question["question"]))
+				if questionID != "" && questionText != "" {
+					questionByID[questionID] = questionText
+				}
+			}
+		}
+	}
+
+	answers := map[string]any{}
+	for key, value := range rawAnswers {
+		answerText := strings.TrimSpace(extractAskUserAnswerText(value))
+		if answerText == "" {
+			continue
+		}
+		questionKey := strings.TrimSpace(key)
+		if mapped := strings.TrimSpace(questionByID[questionKey]); mapped != "" {
+			questionKey = mapped
+		}
+		if questionKey == "" {
+			continue
+		}
+		answers[questionKey] = answerText
+	}
+	if len(answers) == 0 {
+		return output
+	}
+
+	result := map[string]any{
+		"questions": questions,
+		"answers":   answers,
+	}
+	if annotations, ok := payload["annotations"].(map[string]any); ok && len(annotations) > 0 {
+		result["annotations"] = annotations
+	}
+	return result
+}
+
+func extractAskUserAnswerText(v any) string {
+	switch x := v.(type) {
+	case string:
+		return strings.TrimSpace(x)
+	case []any:
+		parts := make([]string, 0, len(x))
+		for _, item := range x {
+			if s := strings.TrimSpace(extractAskUserAnswerText(item)); s != "" {
+				parts = append(parts, s)
+			}
+		}
+		return strings.Join(parts, ", ")
+	case map[string]any:
+		if answers, ok := x["answers"]; ok {
+			return extractAskUserAnswerText(answers)
+		}
+		if answer, ok := x["answer"]; ok {
+			return extractAskUserAnswerText(answer)
+		}
+	}
+	return strings.TrimSpace(asStringValue(v))
 }
 
 func parseJSONMap(raw string) (map[string]any, bool) {

--- a/internal/claude/writer.go
+++ b/internal/claude/writer.go
@@ -95,6 +95,7 @@ func writeSessionJSONL(path, sessionID, cwd, gitBranch string, startedAt time.Ti
 	}
 
 	callIDMap := map[string]string{}
+	droppedCalls := map[string]bool{} // source IDs of lifecycle tool calls to drop
 	prevUUID := ""
 	eventTS := startedAt
 	callCount := 0
@@ -166,6 +167,13 @@ func writeSessionJSONL(path, sessionID, cwd, gitBranch string, startedAt time.Ti
 			if ev.Call == nil {
 				continue
 			}
+			if isCodexLifecycleTool(ev.Call.Name) {
+				sourceID := strings.TrimSpace(ev.Call.SourceID)
+				if sourceID != "" {
+					droppedCalls[sourceID] = true
+				}
+				continue
+			}
 			sourceID := strings.TrimSpace(ev.Call.SourceID)
 			if sourceID == "" {
 				callCount++
@@ -205,6 +213,9 @@ func writeSessionJSONL(path, sessionID, cwd, gitBranch string, startedAt time.Ti
 				continue
 			}
 			callSourceID := strings.TrimSpace(ev.Result.CallSourceID)
+			if droppedCalls[callSourceID] {
+				continue
+			}
 			toolUseID := callIDMap[callSourceID]
 			if toolUseID == "" {
 				toolUseID = "toolu_" + strings.ReplaceAll(uuid.NewString(), "-", "")
@@ -310,7 +321,7 @@ func normalizeCodexToolForClaude(name string, input map[string]any) (string, map
 
 	case "spawn_agent":
 		prompt := strings.TrimSpace(asStringValue(input["message"]))
-		agentType := strings.TrimSpace(asStringValue(input["agent_type"]))
+		agentType := normalizeCodexAgentType(strings.TrimSpace(asStringValue(input["agent_type"])))
 		desc := prompt
 		if len(desc) > 50 {
 			desc = desc[:50]
@@ -329,6 +340,31 @@ func normalizeCodexToolForClaude(name string, input map[string]any) (string, map
 
 	default:
 		return name, input
+	}
+}
+
+// normalizeCodexAgentType maps Codex agent_type values to Claude subagent_type values.
+func normalizeCodexAgentType(agentType string) string {
+	switch strings.ToLower(agentType) {
+	case "explorer":
+		return "Explore"
+	case "planner":
+		return "Plan"
+	case "default", "":
+		return "general-purpose"
+	default:
+		return agentType
+	}
+}
+
+// isCodexLifecycleTool returns true for Codex-only agent lifecycle tools
+// that have no Claude equivalent and should be filtered during conversion.
+func isCodexLifecycleTool(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "wait", "close_agent":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/claude/writer.go
+++ b/internal/claude/writer.go
@@ -23,6 +23,14 @@ var ErrWrite = errors.New("claude native write failed")
 const defaultClaudeVersion = "2.1.63"
 const claudeToolIDLength = 24
 
+// Keep a conservative content budget: Claude session rendering duplicates
+// portions of tool payloads, so this must sit well below nominal model context.
+const claudeContextBudgetChars = 250_000
+const claudeTruncatedKeepChars = 256
+const claudeToolInputSoftLimitChars = 1_024
+const claudeEventHardLimitChars = 2_048
+const claudeToolInputHardLimitChars = 1_024
+
 type Writer struct {
 	ClaudeHome string
 	Now        func() time.Time
@@ -76,6 +84,8 @@ func (w *Writer) Write(ctx context.Context, in session.SessionIR, meta session.C
 }
 
 func writeSessionJSONL(path, sessionID, cwd, gitBranch string, startedAt time.Time, events []session.Event) error {
+	events = normalizeEventsForClaudeContext(events, claudeContextBudgetChars)
+
 	tmp := path + ".tmp"
 	f, err := os.Create(tmp)
 	if err != nil {
@@ -295,6 +305,176 @@ func chooseTS(ev session.Event, fallback, startedAt time.Time) time.Time {
 	return startedAt.UTC()
 }
 
+func normalizeEventsForClaudeContext(events []session.Event, maxChars int) []session.Event {
+	if len(events) == 0 {
+		return events
+	}
+	if maxChars <= 0 {
+		maxChars = claudeContextBudgetChars
+	}
+
+	out := cloneEvents(events)
+	for i := range out {
+		out[i] = trimEventForContext(out[i], claudeEventHardLimitChars, claudeToolInputHardLimitChars)
+	}
+
+	total := estimateEventsChars(out)
+	if total <= maxChars {
+		return out
+	}
+
+	// Progressive passes preserve readability while forcing convergence under budget.
+	passPlan := []struct {
+		keepChars          int
+		toolInputSoftLimit int
+	}{
+		{keepChars: claudeTruncatedKeepChars, toolInputSoftLimit: claudeToolInputSoftLimitChars},
+		{keepChars: 96, toolInputSoftLimit: 256},
+		{keepChars: 24, toolInputSoftLimit: 64},
+	}
+	for _, pass := range passPlan {
+		for i := 0; i < len(out) && total > maxChars; i++ {
+			before := estimateEventChars(out[i])
+			out[i] = trimEventForContext(out[i], pass.keepChars, pass.toolInputSoftLimit)
+			after := estimateEventChars(out[i])
+			total -= before - after
+		}
+		if total <= maxChars {
+			break
+		}
+	}
+
+	return out
+}
+
+func estimateEventsChars(events []session.Event) int {
+	total := 0
+	for _, ev := range events {
+		total += estimateEventChars(ev)
+	}
+	return total
+}
+
+func estimateEventChars(ev session.Event) int {
+	switch ev.Kind {
+	case session.EventUserMessage, session.EventAssistantMessage:
+		if ev.Msg == nil {
+			return 0
+		}
+		return len(ev.Msg.Content)
+	case session.EventToolCall:
+		if ev.Call == nil {
+			return 0
+		}
+		size := len(ev.Call.Name)
+		if ev.Call.Input != nil {
+			if b, err := json.Marshal(ev.Call.Input); err == nil {
+				size += len(b)
+			}
+		}
+		return size
+	case session.EventToolResult:
+		if ev.Result == nil {
+			return 0
+		}
+		return len(ev.Result.Output)
+	default:
+		return 0
+	}
+}
+
+func trimEventForContext(ev session.Event, keepChars, toolInputSoftLimit int) session.Event {
+	switch ev.Kind {
+	case session.EventUserMessage, session.EventAssistantMessage:
+		if ev.Msg == nil {
+			return ev
+		}
+		ev.Msg.Content = truncateForContext(ev.Msg.Content, keepChars)
+	case session.EventToolCall:
+		if ev.Call == nil || ev.Call.Input == nil {
+			return ev
+		}
+		ev.Call.Input = truncateInputForContext(ev.Call.Input, toolInputSoftLimit)
+	case session.EventToolResult:
+		if ev.Result == nil {
+			return ev
+		}
+		ev.Result.Output = truncateForContext(ev.Result.Output, keepChars)
+	}
+	return ev
+}
+
+func truncateForContext(s string, keepChars int) string {
+	if keepChars <= 0 {
+		keepChars = claudeTruncatedKeepChars
+	}
+	if len(s) <= keepChars {
+		return s
+	}
+	head := s[:keepChars]
+	removed := len(s) - keepChars
+	return fmt.Sprintf("[truncated for target model context; original chars=%d, removed=%d]\n%s", len(s), removed, head)
+}
+
+func truncateInputForContext(in map[string]any, limit int) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = truncateAnyForContext(v, limit)
+	}
+	return out
+}
+
+func truncateAnyForContext(v any, limit int) any {
+	switch x := v.(type) {
+	case string:
+		if limit > 0 && len(x) > limit {
+			return truncateForContext(x, limit)
+		}
+		return x
+	case []any:
+		out := make([]any, len(x))
+		for i := range x {
+			out[i] = truncateAnyForContext(x[i], limit)
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, vv := range x {
+			out[k] = truncateAnyForContext(vv, limit)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func cloneEvents(events []session.Event) []session.Event {
+	out := make([]session.Event, 0, len(events))
+	for _, ev := range events {
+		clone := ev
+		switch ev.Kind {
+		case session.EventUserMessage, session.EventAssistantMessage:
+			if ev.Msg != nil {
+				m := *ev.Msg
+				clone.Msg = &m
+			}
+		case session.EventToolCall:
+			if ev.Call != nil {
+				c := *ev.Call
+				c.Input = cloneMap(ev.Call.Input)
+				clone.Call = &c
+			}
+		case session.EventToolResult:
+			if ev.Result != nil {
+				r := *ev.Result
+				clone.Result = &r
+			}
+		}
+		out = append(out, clone)
+	}
+	return out
+}
+
 type toolCallInfo struct {
 	Name  string
 	Input map[string]any
@@ -323,12 +503,8 @@ func buildFileToolUseResult(toolInput map[string]any) map[string]any {
 	filePath := firstNonEmptyString(toolInput["file_path"], toolInput["filePath"], toolInput["path"])
 	oldString := firstNonEmptyString(toolInput["old_string"], toolInput["oldString"])
 	newString := firstNonEmptyString(toolInput["new_string"], toolInput["newString"], toolInput["content"])
+	// Keep migrated output deterministic and bounded: never hydrate from local disk.
 	originalFile := firstNonEmptyString(toolInput["original_file"], toolInput["originalFile"], oldString)
-	if originalFile == "" && filePath != "" {
-		if b, err := os.ReadFile(filePath); err == nil {
-			originalFile = string(b)
-		}
-	}
 
 	replaceAll := false
 	if b, ok := asBoolValue(toolInput["replace_all"]); ok {

--- a/internal/claude/writer_test.go
+++ b/internal/claude/writer_test.go
@@ -158,7 +158,7 @@ func TestWriterNormalizesCodexToolNames(t *testing.T) {
 			},
 		},
 		{
-			name:     "spawn_agent to Agent",
+			name:     "spawn_agent to Agent with default type",
 			toolName: "spawn_agent",
 			input:    map[string]any{"agent_type": "default", "message": "search for bugs"},
 			wantName: "Agent",
@@ -166,8 +166,41 @@ func TestWriterNormalizesCodexToolNames(t *testing.T) {
 				if input["prompt"] != "search for bugs" {
 					t.Fatalf("prompt: %v", input["prompt"])
 				}
-				if input["subagent_type"] != "default" {
-					t.Fatalf("subagent_type: %v", input["subagent_type"])
+				if input["subagent_type"] != "general-purpose" {
+					t.Fatalf("subagent_type: got %v want general-purpose", input["subagent_type"])
+				}
+			},
+		},
+		{
+			name:     "spawn_agent normalizes explorer to Explore",
+			toolName: "spawn_agent",
+			input:    map[string]any{"agent_type": "explorer", "message": "find files"},
+			wantName: "Agent",
+			wantCheck: func(t *testing.T, input map[string]any) {
+				if input["subagent_type"] != "Explore" {
+					t.Fatalf("subagent_type: got %v want Explore", input["subagent_type"])
+				}
+			},
+		},
+		{
+			name:     "spawn_agent normalizes planner to Plan",
+			toolName: "spawn_agent",
+			input:    map[string]any{"agent_type": "planner", "message": "design approach"},
+			wantName: "Agent",
+			wantCheck: func(t *testing.T, input map[string]any) {
+				if input["subagent_type"] != "Plan" {
+					t.Fatalf("subagent_type: got %v want Plan", input["subagent_type"])
+				}
+			},
+		},
+		{
+			name:     "spawn_agent empty type defaults to general-purpose",
+			toolName: "spawn_agent",
+			input:    map[string]any{"agent_type": "", "message": "do stuff"},
+			wantName: "Agent",
+			wantCheck: func(t *testing.T, input map[string]any) {
+				if input["subagent_type"] != "general-purpose" {
+					t.Fatalf("subagent_type: got %v want general-purpose", input["subagent_type"])
 				}
 			},
 		},
@@ -201,6 +234,94 @@ func TestWriterNormalizesCodexToolNames(t *testing.T) {
 				tt.wantCheck(t, gotInput)
 			}
 		})
+	}
+}
+
+func TestWriterDropsCodexLifecycleTools(t *testing.T) {
+	home := t.TempDir()
+	w := NewWriter(home)
+	now := time.Date(2026, 3, 1, 8, 0, 0, 0, time.UTC)
+	w.Now = func() time.Time { return now }
+
+	ir := session.SessionIR{
+		SourceID:  "codex-thread-lifecycle",
+		CWD:       "/tmp/test",
+		StartedAt: now,
+		OrderedEvents: []session.Event{
+			{Kind: session.EventUserMessage, Msg: &session.Message{Role: "user", Content: "hello", Timestamp: now}},
+			// spawn_agent should be kept
+			{Kind: session.EventToolCall, Call: &session.ToolCall{SourceID: "call_spawn", Name: "spawn_agent", Input: map[string]any{"agent_type": "explorer", "message": "find stuff"}, Timestamp: now.Add(time.Second)}},
+			{Kind: session.EventToolResult, Result: &session.ToolResult{CallSourceID: "call_spawn", Output: `{"agent_id":"abc-123"}`, Timestamp: now.Add(2 * time.Second)}},
+			// wait should be dropped
+			{Kind: session.EventToolCall, Call: &session.ToolCall{SourceID: "call_wait", Name: "wait", Input: map[string]any{"ids": []any{"abc-123"}, "timeout_ms": 120000}, Timestamp: now.Add(3 * time.Second)}},
+			{Kind: session.EventToolResult, Result: &session.ToolResult{CallSourceID: "call_wait", Output: `{"status":"completed"}`, Timestamp: now.Add(4 * time.Second)}},
+			// close_agent should be dropped
+			{Kind: session.EventToolCall, Call: &session.ToolCall{SourceID: "call_close", Name: "close_agent", Input: map[string]any{"id": "abc-123"}, Timestamp: now.Add(5 * time.Second)}},
+			{Kind: session.EventToolResult, Result: &session.ToolResult{CallSourceID: "call_close", Output: `{"status":"closed"}`, Timestamp: now.Add(6 * time.Second)}},
+			{Kind: session.EventAssistantMessage, Msg: &session.Message{Role: "assistant", Content: "done", Timestamp: now.Add(7 * time.Second)}},
+		},
+	}
+
+	_, sessionPath, err := w.Write(context.Background(), ir, session.ClaudeSessionMeta{CWD: ir.CWD})
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	f, err := os.Open(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var toolNames []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var line map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			t.Fatalf("bad json: %v", err)
+		}
+		msg, _ := line["message"].(map[string]any)
+		if msg == nil {
+			continue
+		}
+		content, _ := msg["content"].([]any)
+		if len(content) == 0 {
+			continue
+		}
+		first, _ := content[0].(map[string]any)
+		if first == nil {
+			continue
+		}
+		if kind, _ := first["type"].(string); kind == "tool_use" {
+			name, _ := first["name"].(string)
+			toolNames = append(toolNames, name)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only spawn_agent (normalized to Agent) should remain; wait and close_agent should be filtered.
+	if len(toolNames) != 1 {
+		t.Fatalf("expected 1 tool call, got %d: %v", len(toolNames), toolNames)
+	}
+	if toolNames[0] != "Agent" {
+		t.Fatalf("expected Agent, got %q", toolNames[0])
+	}
+}
+
+func TestIsCodexLifecycleTool(t *testing.T) {
+	lifecycle := []string{"wait", "close_agent", "Wait", "CLOSE_AGENT"}
+	for _, name := range lifecycle {
+		if !isCodexLifecycleTool(name) {
+			t.Fatalf("expected %q to be lifecycle tool", name)
+		}
+	}
+	notLifecycle := []string{"shell_command", "spawn_agent", "apply_patch", "mcp__foo__bar"}
+	for _, name := range notLifecycle {
+		if isCodexLifecycleTool(name) {
+			t.Fatalf("expected %q to NOT be lifecycle tool", name)
+		}
 	}
 }
 

--- a/internal/claude/writer_test.go
+++ b/internal/claude/writer_test.go
@@ -895,6 +895,26 @@ func TestNormalizeEventsForClaudeContextAppliesPerEventHardLimit(t *testing.T) {
 	}
 }
 
+func TestTruncateForContextAvoidsNestedMarkers(t *testing.T) {
+	orig := strings.Repeat("output-line\n", 500)
+	first := truncateForContext(orig, 256)
+	second := truncateForContext(first, 96)
+
+	if got := strings.Count(second, claudeTruncationPrefix); got != 1 {
+		t.Fatalf("expected a single truncation marker, got %d in %q", got, second[:min(len(second), 120)])
+	}
+	body, ok := unwrapTruncatedBody(second)
+	if !ok {
+		t.Fatalf("expected truncation body")
+	}
+	if strings.HasPrefix(body, claudeTruncationPrefix) {
+		t.Fatalf("body should contain payload content, got nested marker")
+	}
+	if strings.TrimSpace(body) == "" {
+		t.Fatalf("body should retain payload content")
+	}
+}
+
 func TestNormalizeEventsForClaudeContextDoesNotMutateInput(t *testing.T) {
 	huge := strings.Repeat("B", 5000)
 	events := []session.Event{

--- a/internal/claude/writer_test.go
+++ b/internal/claude/writer_test.go
@@ -290,6 +290,87 @@ func TestWriterBuildsStructuredEditToolUseResult(t *testing.T) {
 	}
 }
 
+func TestWriterEditToolUseResultDoesNotReadOriginalFileFromDisk(t *testing.T) {
+	home := t.TempDir()
+	w := NewWriter(home)
+	now := time.Date(2026, 3, 1, 8, 0, 0, 0, time.UTC)
+	w.Now = func() time.Time { return now }
+
+	workspace := t.TempDir()
+	target := filepath.Join(workspace, "main.go")
+	if err := os.WriteFile(target, []byte(strings.Repeat("x", 50_000)), 0o644); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+
+	ir := session.SessionIR{
+		SourceID:  "codex-thread-edit-no-disk-hydrate",
+		CWD:       workspace,
+		StartedAt: now,
+		OrderedEvents: []session.Event{
+			{Kind: session.EventToolCall, Call: &session.ToolCall{
+				SourceID: "call_edit_1",
+				Name:     "Edit",
+				Input: map[string]any{
+					"file_path":  target,
+					"new_string": "new",
+				},
+				Timestamp: now.Add(time.Second),
+			}},
+			{Kind: session.EventToolResult, Result: &session.ToolResult{
+				CallSourceID: "call_edit_1",
+				Output:       "ok",
+				Timestamp:    now.Add(2 * time.Second),
+			}},
+		},
+	}
+
+	_, sessionPath, err := w.Write(context.Background(), ir, session.ClaudeSessionMeta{CWD: ir.CWD})
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	f, err := os.Open(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var editToolUseResult map[string]any
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var line map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			t.Fatalf("bad json line: %v", err)
+		}
+		msg, _ := line["message"].(map[string]any)
+		if msg == nil {
+			continue
+		}
+		content, _ := msg["content"].([]any)
+		if len(content) == 0 {
+			continue
+		}
+		first, _ := content[0].(map[string]any)
+		if first == nil {
+			continue
+		}
+		if kind, _ := first["type"].(string); kind == "tool_result" {
+			var ok bool
+			editToolUseResult, ok = line["toolUseResult"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected Edit toolUseResult object, got %T", line["toolUseResult"])
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, _ := editToolUseResult["originalFile"].(string); got != "" {
+		t.Fatalf("originalFile should not be hydrated from disk: len=%d", len(got))
+	}
+}
+
 func TestWriterBuildsStructuredAgentToolUseResult(t *testing.T) {
 	home := t.TempDir()
 	w := NewWriter(home)
@@ -733,5 +814,117 @@ func TestExtractPatchFilePath(t *testing.T) {
 		if got != tt.want {
 			t.Fatalf("extractPatchFilePath(%q): got %q want %q", tt.patch[:min(30, len(tt.patch))], got, tt.want)
 		}
+	}
+}
+
+func TestNormalizeEventsForClaudeContextTruncatesOldContent(t *testing.T) {
+	huge := strings.Repeat("A", 4000)
+	events := []session.Event{
+		{
+			Kind: session.EventUserMessage,
+			Msg: &session.Message{
+				Role:    "user",
+				Content: huge,
+			},
+		},
+		{
+			Kind: session.EventToolCall,
+			Call: &session.ToolCall{
+				SourceID: "call_1",
+				Name:     "Edit",
+				Input: map[string]any{
+					"file_path":  "src/main.go",
+					"new_string": huge,
+				},
+			},
+		},
+		{
+			Kind: session.EventToolResult,
+			Result: &session.ToolResult{
+				CallSourceID: "call_1",
+				Output:       huge,
+			},
+		},
+		{
+			Kind: session.EventAssistantMessage,
+			Msg: &session.Message{
+				Role:    "assistant",
+				Content: "kept recent context",
+			},
+		},
+	}
+
+	out := normalizeEventsForClaudeContext(events, 1300)
+	if got, want := estimateEventsChars(out) <= 1300, true; got != want {
+		t.Fatalf("expected trimmed events within budget, got=%d", estimateEventsChars(out))
+	}
+
+	first := out[0].Msg.Content
+	if !strings.HasPrefix(first, "[truncated for target model context;") {
+		t.Fatalf("expected first message to be truncated, got %q", first[:min(len(first), 80)])
+	}
+	if got := out[3].Msg.Content; got != "kept recent context" {
+		t.Fatalf("recent assistant message should remain intact, got %q", got)
+	}
+
+	toolInput := out[1].Call.Input
+	newString, _ := toolInput["new_string"].(string)
+	if !strings.HasPrefix(newString, "[truncated for target model context;") {
+		t.Fatalf("expected tool input new_string truncation, got %q", newString[:min(len(newString), 80)])
+	}
+}
+
+func TestNormalizeEventsForClaudeContextAppliesPerEventHardLimit(t *testing.T) {
+	huge := strings.Repeat("Z", claudeEventHardLimitChars+500)
+	events := []session.Event{
+		{
+			Kind: session.EventToolResult,
+			Result: &session.ToolResult{
+				CallSourceID: "call_1",
+				Output:       huge,
+			},
+		},
+	}
+
+	out := normalizeEventsForClaudeContext(events, 10_000_000)
+	if len(out) != 1 || out[0].Result == nil {
+		t.Fatalf("unexpected output shape: %#v", out)
+	}
+	if got := out[0].Result.Output; !strings.HasPrefix(got, "[truncated for target model context;") {
+		t.Fatalf("expected hard-limit truncation, got %q", got[:min(len(got), 80)])
+	}
+}
+
+func TestNormalizeEventsForClaudeContextDoesNotMutateInput(t *testing.T) {
+	huge := strings.Repeat("B", 5000)
+	events := []session.Event{
+		{
+			Kind: session.EventUserMessage,
+			Msg: &session.Message{
+				Role:    "user",
+				Content: huge,
+			},
+		},
+		{
+			Kind: session.EventToolCall,
+			Call: &session.ToolCall{
+				SourceID: "call_1",
+				Name:     "Edit",
+				Input: map[string]any{
+					"file_path":  "src/main.go",
+					"new_string": huge,
+				},
+			},
+		},
+	}
+
+	_ = normalizeEventsForClaudeContext(events, 1200)
+
+	if got := events[0].Msg.Content; got != huge {
+		t.Fatalf("input message mutated")
+	}
+	gotNewString, _ := events[1].Call.Input["new_string"].(string)
+	if gotNewString != huge {
+		t.Fatalf("input call args mutated")
 	}
 }

--- a/internal/claude/writer_test.go
+++ b/internal/claude/writer_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -60,6 +61,7 @@ func TestWriterWritesSessionAndIndex(t *testing.T) {
 	var sawToolUse bool
 	var sawToolResult bool
 	var toolUseID string
+	var bashToolUseResult map[string]any
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		var line map[string]any
@@ -91,6 +93,11 @@ func TestWriterWritesSessionAndIndex(t *testing.T) {
 			if got, _ := first["tool_use_id"].(string); got == "" || got != toolUseID {
 				t.Fatalf("tool_result id mismatch: got %q want %q", got, toolUseID)
 			}
+			var ok bool
+			bashToolUseResult, ok = line["toolUseResult"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected Bash toolUseResult object, got %T", line["toolUseResult"])
+			}
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -98,6 +105,269 @@ func TestWriterWritesSessionAndIndex(t *testing.T) {
 	}
 	if !sawToolUse || !sawToolResult {
 		t.Fatalf("missing tool records: use=%v result=%v", sawToolUse, sawToolResult)
+	}
+	if ok, err := regexp.MatchString(`^toolu_[0-9A-Za-z]{24}$`, toolUseID); err != nil || !ok {
+		t.Fatalf("tool_use id format mismatch: %q", toolUseID)
+	}
+	if got, _ := bashToolUseResult["stdout"].(string); got != "M foo.go" {
+		t.Fatalf("bash stdout mismatch: got %q want %q", got, "M foo.go")
+	}
+	if got, _ := bashToolUseResult["stderr"].(string); got != "" {
+		t.Fatalf("bash stderr mismatch: got %q want empty", got)
+	}
+	if got, ok := bashToolUseResult["interrupted"].(bool); !ok || got {
+		t.Fatalf("bash interrupted mismatch: got %#v", bashToolUseResult["interrupted"])
+	}
+	if got, ok := bashToolUseResult["isImage"].(bool); !ok || got {
+		t.Fatalf("bash isImage mismatch: got %#v", bashToolUseResult["isImage"])
+	}
+	if got, ok := bashToolUseResult["noOutputExpected"].(bool); !ok || got {
+		t.Fatalf("bash noOutputExpected mismatch: got %#v", bashToolUseResult["noOutputExpected"])
+	}
+}
+
+func TestWriterUnwrapsJSONWrappedToolResultOutput(t *testing.T) {
+	home := t.TempDir()
+	w := NewWriter(home)
+	now := time.Date(2026, 3, 1, 8, 0, 0, 0, time.UTC)
+	w.Now = func() time.Time { return now }
+
+	ir := session.SessionIR{
+		SourceID:  "codex-thread-json-output",
+		CWD:       "/Users/mithilesh/Code/clis/resume",
+		StartedAt: now,
+		OrderedEvents: []session.Event{
+			{Kind: session.EventUserMessage, Msg: &session.Message{Role: "user", Content: "apply patch", Timestamp: now}},
+			{Kind: session.EventToolCall, Call: &session.ToolCall{
+				SourceID:  "call_edit_1",
+				Name:      "Edit",
+				Input:     map[string]any{"file_path": "src/main.go", "old_string": "old", "new_string": "new"},
+				Timestamp: now.Add(time.Second),
+			}},
+			{Kind: session.EventToolResult, Result: &session.ToolResult{
+				CallSourceID: "call_edit_1",
+				Output: `{"output":"Success. Updated the following files:
+M src/main.go
+","metadata":{"exit_code":0}}`,
+				Timestamp: now.Add(2 * time.Second),
+			}},
+		},
+	}
+
+	_, sessionPath, err := w.Write(context.Background(), ir, session.ClaudeSessionMeta{CWD: ir.CWD})
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	f, err := os.Open(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var toolResultContent string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var line map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			t.Fatalf("bad json line: %v", err)
+		}
+		msg, _ := line["message"].(map[string]any)
+		if msg == nil {
+			continue
+		}
+		content, _ := msg["content"].([]any)
+		if len(content) == 0 {
+			continue
+		}
+		first, _ := content[0].(map[string]any)
+		if first == nil {
+			continue
+		}
+		if kind, _ := first["type"].(string); kind == "tool_result" {
+			toolResultContent, _ = first["content"].(string)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.HasPrefix(strings.TrimSpace(toolResultContent), "{") {
+		t.Fatalf("tool_result should be unwrapped plain text, got: %q", toolResultContent)
+	}
+	if !strings.Contains(toolResultContent, "Success. Updated the following files") {
+		t.Fatalf("expected unwrapped success message, got: %q", toolResultContent)
+	}
+}
+
+func TestWriterBuildsStructuredEditToolUseResult(t *testing.T) {
+	home := t.TempDir()
+	w := NewWriter(home)
+	now := time.Date(2026, 3, 1, 8, 0, 0, 0, time.UTC)
+	w.Now = func() time.Time { return now }
+
+	ir := session.SessionIR{
+		SourceID:  "codex-thread-edit-result-shape",
+		CWD:       "/Users/mithilesh/Code/clis/resume",
+		StartedAt: now,
+		OrderedEvents: []session.Event{
+			{Kind: session.EventToolCall, Call: &session.ToolCall{
+				SourceID:  "call_edit_1",
+				Name:      "Edit",
+				Input:     map[string]any{"file_path": "src/main.go", "old_string": "old", "new_string": "new", "replace_all": false},
+				Timestamp: now.Add(time.Second),
+			}},
+			{Kind: session.EventToolResult, Result: &session.ToolResult{
+				CallSourceID: "call_edit_1",
+				Output:       "The file src/main.go has been updated successfully.",
+				Timestamp:    now.Add(2 * time.Second),
+			}},
+		},
+	}
+
+	_, sessionPath, err := w.Write(context.Background(), ir, session.ClaudeSessionMeta{CWD: ir.CWD})
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	f, err := os.Open(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var editToolUseResult map[string]any
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var line map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			t.Fatalf("bad json line: %v", err)
+		}
+		msg, _ := line["message"].(map[string]any)
+		if msg == nil {
+			continue
+		}
+		content, _ := msg["content"].([]any)
+		if len(content) == 0 {
+			continue
+		}
+		first, _ := content[0].(map[string]any)
+		if first == nil {
+			continue
+		}
+		if kind, _ := first["type"].(string); kind == "tool_result" {
+			var ok bool
+			editToolUseResult, ok = line["toolUseResult"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected Edit toolUseResult object, got %T", line["toolUseResult"])
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, _ := editToolUseResult["filePath"].(string); got != "src/main.go" {
+		t.Fatalf("filePath mismatch: got %q want %q", got, "src/main.go")
+	}
+	if got, _ := editToolUseResult["oldString"].(string); got != "old" {
+		t.Fatalf("oldString mismatch: got %q want %q", got, "old")
+	}
+	if got, _ := editToolUseResult["newString"].(string); got != "new" {
+		t.Fatalf("newString mismatch: got %q want %q", got, "new")
+	}
+	if _, ok := editToolUseResult["originalFile"].(string); !ok {
+		t.Fatalf("originalFile should be string: %#v", editToolUseResult["originalFile"])
+	}
+	if _, ok := editToolUseResult["structuredPatch"].([]any); !ok {
+		t.Fatalf("structuredPatch should be []any: %#v", editToolUseResult["structuredPatch"])
+	}
+	if got, ok := editToolUseResult["replaceAll"].(bool); !ok || got {
+		t.Fatalf("replaceAll mismatch: got %#v", editToolUseResult["replaceAll"])
+	}
+	if got, ok := editToolUseResult["userModified"].(bool); !ok || got {
+		t.Fatalf("userModified mismatch: got %#v", editToolUseResult["userModified"])
+	}
+}
+
+func TestWriterBuildsStructuredAgentToolUseResult(t *testing.T) {
+	home := t.TempDir()
+	w := NewWriter(home)
+	now := time.Date(2026, 3, 1, 8, 0, 0, 0, time.UTC)
+	w.Now = func() time.Time { return now }
+
+	ir := session.SessionIR{
+		SourceID:  "codex-thread-agent-result-shape",
+		CWD:       "/Users/mithilesh/Code/clis/resume",
+		StartedAt: now,
+		OrderedEvents: []session.Event{
+			{Kind: session.EventToolCall, Call: &session.ToolCall{
+				SourceID:  "call_agent_1",
+				Name:      "spawn_agent",
+				Input:     map[string]any{"agent_type": "explorer", "message": "find tests"},
+				Timestamp: now.Add(time.Second),
+			}},
+			{Kind: session.EventToolResult, Result: &session.ToolResult{
+				CallSourceID: "call_agent_1",
+				Output:       `{"agent_id":"abc-123","status":"completed"}`,
+				Timestamp:    now.Add(2 * time.Second),
+			}},
+		},
+	}
+
+	_, sessionPath, err := w.Write(context.Background(), ir, session.ClaudeSessionMeta{CWD: ir.CWD})
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	f, err := os.Open(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var agentToolUseResult map[string]any
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var line map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			t.Fatalf("bad json line: %v", err)
+		}
+		msg, _ := line["message"].(map[string]any)
+		if msg == nil {
+			continue
+		}
+		content, _ := msg["content"].([]any)
+		if len(content) == 0 {
+			continue
+		}
+		first, _ := content[0].(map[string]any)
+		if first == nil {
+			continue
+		}
+		if kind, _ := first["type"].(string); kind == "tool_result" {
+			var ok bool
+			agentToolUseResult, ok = line["toolUseResult"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected Agent toolUseResult object, got %T", line["toolUseResult"])
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, _ := agentToolUseResult["agentId"].(string); got != "abc-123" {
+		t.Fatalf("agentId mismatch: got %q want %q", got, "abc-123")
+	}
+	if got, _ := agentToolUseResult["status"].(string); got != "completed" {
+		t.Fatalf("status mismatch: got %q want %q", got, "completed")
+	}
+	if got, _ := agentToolUseResult["prompt"].(string); got != "find tests" {
+		t.Fatalf("prompt mismatch: got %q want %q", got, "find tests")
+	}
+	if got, ok := agentToolUseResult["usage"].(map[string]any); !ok || got == nil {
+		t.Fatalf("usage mismatch: %#v", agentToolUseResult["usage"])
 	}
 }
 
@@ -209,6 +479,35 @@ func TestWriterNormalizesCodexToolNames(t *testing.T) {
 			toolName: "request_user_input",
 			input:    map[string]any{"message": "which option?"},
 			wantName: "AskUserQuestion",
+		},
+		{
+			name:     "Edit normalizes filePath alias",
+			toolName: "Edit",
+			input:    map[string]any{"filePath": "src/main.go", "old_string": "old", "new_string": "new"},
+			wantName: "Edit",
+			wantCheck: func(t *testing.T, input map[string]any) {
+				if input["file_path"] != "src/main.go" {
+					t.Fatalf("file_path: got %v want src/main.go", input["file_path"])
+				}
+				if _, ok := input["filePath"]; ok {
+					t.Fatalf("filePath alias should be removed: %+v", input)
+				}
+			},
+		},
+		{
+			name:     "Edit defaults empty file_path when missing",
+			toolName: "Edit",
+			input:    map[string]any{"new_string": "content"},
+			wantName: "Edit",
+			wantCheck: func(t *testing.T, input map[string]any) {
+				v, ok := input["file_path"].(string)
+				if !ok {
+					t.Fatalf("file_path missing or non-string: %+v", input)
+				}
+				if v != "" {
+					t.Fatalf("file_path: got %q want empty string", v)
+				}
+			},
 		},
 		{
 			name:     "update_plan to TodoWrite",

--- a/internal/claude/writer_test.go
+++ b/internal/claude/writer_test.go
@@ -371,6 +371,99 @@ func TestWriterBuildsStructuredAgentToolUseResult(t *testing.T) {
 	}
 }
 
+func TestWriterBuildsStructuredAskUserQuestionToolUseResult(t *testing.T) {
+	home := t.TempDir()
+	w := NewWriter(home)
+	now := time.Date(2026, 3, 1, 8, 0, 0, 0, time.UTC)
+	w.Now = func() time.Time { return now }
+
+	ir := session.SessionIR{
+		SourceID:  "codex-thread-ask-user-question",
+		CWD:       "/Users/mithilesh/Code/clis/resume",
+		StartedAt: now,
+		OrderedEvents: []session.Event{
+			{Kind: session.EventToolCall, Call: &session.ToolCall{
+				SourceID: "call_ask_1",
+				Name:     "request_user_input",
+				Input: map[string]any{
+					"questions": []any{
+						map[string]any{
+							"id":       "fix_scope",
+							"header":   "Fix scope",
+							"question": "For the first patch, which compatibility scope do you want?",
+							"options": []any{
+								map[string]any{"label": "Edit-first (Recommended)", "description": "smallest change"},
+								map[string]any{"label": "All tool parity", "description": "broader change"},
+							},
+						},
+					},
+				},
+				Timestamp: now.Add(time.Second),
+			}},
+			{Kind: session.EventToolResult, Result: &session.ToolResult{
+				CallSourceID: "call_ask_1",
+				Output:       `{"answers":{"fix_scope":{"answers":["All tool parity"]}}}`,
+				Timestamp:    now.Add(2 * time.Second),
+			}},
+		},
+	}
+
+	_, sessionPath, err := w.Write(context.Background(), ir, session.ClaudeSessionMeta{CWD: ir.CWD})
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	f, err := os.Open(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var askToolUseResult map[string]any
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var line map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			t.Fatalf("bad json line: %v", err)
+		}
+		msg, _ := line["message"].(map[string]any)
+		if msg == nil {
+			continue
+		}
+		content, _ := msg["content"].([]any)
+		if len(content) == 0 {
+			continue
+		}
+		first, _ := content[0].(map[string]any)
+		if first == nil {
+			continue
+		}
+		if kind, _ := first["type"].(string); kind == "tool_result" {
+			var ok bool
+			askToolUseResult, ok = line["toolUseResult"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected AskUserQuestion toolUseResult object, got %T", line["toolUseResult"])
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	questions, ok := askToolUseResult["questions"].([]any)
+	if !ok || len(questions) == 0 {
+		t.Fatalf("questions mismatch: %#v", askToolUseResult["questions"])
+	}
+	answers, ok := askToolUseResult["answers"].(map[string]any)
+	if !ok {
+		t.Fatalf("answers mismatch: %#v", askToolUseResult["answers"])
+	}
+	key := "For the first patch, which compatibility scope do you want?"
+	if got, _ := answers[key].(string); got != "All tool parity" {
+		t.Fatalf("answer mismatch: got %q want %q", got, "All tool parity")
+	}
+}
+
 func TestWriterNormalizesCodexToolNames(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -260,8 +260,44 @@ func normalizeToolCall(name string, input map[string]any) (string, map[string]an
 		}
 		cmd := fmt.Sprintf("sed -n '%d,%dp' %s", start, end, shellQuote(path))
 		return "shell_command", map[string]any{"command": cmd}
+	case "agent":
+		message := strings.TrimSpace(asString(input["message"]))
+		if message == "" {
+			message = strings.TrimSpace(asString(input["prompt"]))
+		}
+
+		agentType := strings.TrimSpace(asString(input["agent_type"]))
+		if agentType == "" {
+			agentType = strings.TrimSpace(asString(input["subagent_type"]))
+		}
+		agentType = normalizeClaudeSubagentType(agentType)
+
+		out := map[string]any{}
+		if message != "" {
+			out["message"] = message
+		}
+		if agentType != "" {
+			out["agent_type"] = agentType
+		}
+		if items, ok := input["items"]; ok {
+			out["items"] = items
+		}
+		return "spawn_agent", out
 	}
 	return strings.TrimSpace(name), input
+}
+
+func normalizeClaudeSubagentType(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "explore":
+		return "explorer"
+	case "plan":
+		return "planner"
+	case "general-purpose", "default":
+		return "default"
+	default:
+		return strings.TrimSpace(v)
+	}
 }
 
 func asString(v any) string {

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -92,6 +92,8 @@ func TestConvertNormalizesClaudeToolCallNamesAndArgs(t *testing.T) {
 			{Kind: session.EventToolResult, Result: &session.ToolResult{CallSourceID: "toolu_read", Output: "module example", Timestamp: ts.Add(4 * time.Second)}},
 			{Kind: session.EventToolCall, Call: &session.ToolCall{SourceID: "toolu_bash", Name: "Bash", Input: map[string]any{"command": "git status --short", "description": "show status"}, Timestamp: ts.Add(5 * time.Second), Index: 3}},
 			{Kind: session.EventToolResult, Result: &session.ToolResult{CallSourceID: "toolu_bash", Output: "", Timestamp: ts.Add(6 * time.Second)}},
+			{Kind: session.EventToolCall, Call: &session.ToolCall{SourceID: "toolu_agent", Name: "Agent", Input: map[string]any{"prompt": "find tests", "subagent_type": "Explore"}, Timestamp: ts.Add(7 * time.Second), Index: 4}},
+			{Kind: session.EventToolResult, Result: &session.ToolResult{CallSourceID: "toolu_agent", Output: `{"agent_id":"abc-123"}`, Timestamp: ts.Add(8 * time.Second)}},
 		},
 	}
 
@@ -100,6 +102,7 @@ func TestConvertNormalizesClaudeToolCallNamesAndArgs(t *testing.T) {
 			"call_111111111111111111111111",
 			"call_222222222222222222222222",
 			"call_333333333333333333333333",
+			"call_444444444444444444444444",
 		}},
 		Now: func() time.Time { return ts },
 	}
@@ -150,5 +153,45 @@ func TestConvertNormalizesClaudeToolCallNamesAndArgs(t *testing.T) {
 	}
 	if bashCall.Arguments["description"] != "show status" {
 		t.Fatalf("bash description missing: %#v", bashCall.Arguments)
+	}
+
+	agentCall, ok := calls["call_444444444444444444444444"]
+	if !ok {
+		t.Fatalf("missing agent call: %+v", out.Items)
+	}
+	if agentCall.Name != "spawn_agent" {
+		t.Fatalf("agent name mismatch: %q", agentCall.Name)
+	}
+	if agentCall.Arguments["message"] != "find tests" {
+		t.Fatalf("agent message mismatch: %#v", agentCall.Arguments)
+	}
+	if agentCall.Arguments["agent_type"] != "explorer" {
+		t.Fatalf("agent type mismatch: %#v", agentCall.Arguments)
+	}
+	if _, exists := agentCall.Arguments["subagent_type"]; exists {
+		t.Fatalf("unexpected subagent_type key: %#v", agentCall.Arguments)
+	}
+	if _, exists := agentCall.Arguments["prompt"]; exists {
+		t.Fatalf("unexpected prompt key: %#v", agentCall.Arguments)
+	}
+}
+
+func TestNormalizeClaudeSubagentType(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: "Explore", want: "explorer"},
+		{in: "Plan", want: "planner"},
+		{in: "general-purpose", want: "default"},
+		{in: "default", want: "default"},
+		{in: "worker", want: "worker"},
+		{in: "", want: ""},
+	}
+	for _, tt := range tests {
+		got := normalizeClaudeSubagentType(tt.in)
+		if got != tt.want {
+			t.Fatalf("normalizeClaudeSubagentType(%q): got %q want %q", tt.in, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- map Codex lifecycle tools in `codex -> claude`: drop `wait`/`close_agent` and normalize `spawn_agent` subagent types (`explorer -> Explore`, etc.)
- map Claude agent tool in `claude -> codex`: convert `Agent` to native `spawn_agent`
- translate Claude `prompt/subagent_type` to Codex `message/agent_type`

## Tests
- extended `internal/claude/writer_test.go` with lifecycle filtering + agent type normalization cases
- extended `internal/converter/converter_test.go` with `Agent -> spawn_agent` and subagent type mapping coverage
- added `TestNormalizeClaudeSubagentType`
- ran `make test` successfully
